### PR TITLE
fix: delay elaboration of index notation until types are known

### DIFF
--- a/LeanColls/Classes/Indexed/Notation.lean
+++ b/LeanColls/Classes/Indexed/Notation.lean
@@ -149,7 +149,7 @@ private def elabIndices (ids : TSyntaxArray ``elemIndex) (Is : Array Expr) :
 
 
 open Lean Elab Term Meta Qq in
-elab_rules (kind:=indexedGet) : term
+elab_rules (kind:=indexedGet) : term <= _expectedType
 | `($x[$ids:elemIndex,*]) => do
 
   let ids := ids.getElems

--- a/test/IndexedNotation.lean
+++ b/test/IndexedNotation.lean
@@ -42,6 +42,18 @@ variable (x : NDArray Nat (Fin 10)) (t : NDArray Nat (Fin 10 × Fin 20 × Fin 20
       a[i,j] /= 42
       a[i,j] •= 42
 
+
+section IndexNotationElabIssue
+
+variable {Cont Idx Elem} [IndexType Idx] [Indexed Cont Idx Elem] [Inhabited Elem]
+example (f : Idx → Elem) :
+  Function.invFun (fun (f : Idx → Elem) => Indexed.ofFn (C:=Cont) f)
+  =
+  -- elaboration of `x[i]` used to cause 'internal exception: isDefEqStuck'
+  fun x i => x[i] := sorry
+
+end IndexNotationElabIssue
+
 -- check we didn't mess up Lean's indexing
 variable (a : Array Nat) (i j : Fin a.size)
 


### PR DESCRIPTION
Fixed #19 by delaying elaboration until the types in `x[i]` are known.

I know nothing about elaboration so this might not be a complete fix and the notation might be still broken.