### PR TITLE
Refactor operations

### DIFF
--- a/LeanColls/Classes/Ops.lean
+++ b/LeanColls/Classes/Ops.lean
@@ -4,6 +4,9 @@ Authors: James Gallicchio
 -/
 
 import LeanColls.MathlibUpstream
+import Mathlib.Data.Finset.Image
+import Mathlib.Data.Finset.Prod
+import Mathlib.Data.Finset.Sum
 
 /-! ## Collection operations
 
@@ -34,86 +37,201 @@ namespace LeanColls
 
 /-! ### Models -/
 
+/-- `C` can be modeled as a set of `τ`s -/
+class ToSet (C : Type u) (τ : outParam (Type v)) where
+  toSet : (cont : C) → Set τ
+export ToSet (toSet)
+
 /-- `C` can be modeled as a finset of `τ`s -/
 class ToFinset (C : Type u) (τ : outParam (Type v)) where
   toFinset : (cont : C) → Finset τ
+export ToFinset (toFinset)
 
 /-- `C` can be modeled as a multiset of `τ`s -/
 class ToMultiset (C : Type u) (τ : outParam (Type v)) where
   toMultiset : (cont : C) → Multiset τ
+export ToMultiset (toMultiset)
 
-class LawfulToMultiset (C : Type u) (τ : outParam (Type v))
-        [DecidableEq τ] [ToFinset C τ] [ToMultiset C τ] where
-  toFinset_toMultiset : ∀ (cont : C),
-    (ToMultiset.toMultiset cont).toFinset = ToFinset.toFinset cont
-
-attribute [simp] LawfulToMultiset.toFinset_toMultiset
-
-instance [DecidableEq τ] [ToMultiset C τ] : ToFinset C τ where
-  toFinset c := (ToMultiset.toMultiset c).toFinset
-
-instance [DecidableEq τ] [ToMultiset C τ] : LawfulToMultiset C τ where
-  toFinset_toMultiset _ := rfl
-
+/-- `C` can be modeled as a list of `τ`s -/
 class ToList (C : Type u) (τ : outParam (Type v)) where
   toList : (cont : C) → List τ
 export ToList (toList)
 
-class LawfulToList (C : Type u) (τ : outParam (Type v))
-        [ToMultiset C τ] [ToList C τ] where
-  toMultiset_toList : ∀ (cont : C), (toList cont) = ToMultiset.toMultiset cont
+/-! #### Hierarchical Instances
 
-attribute [simp] LawfulToMultiset.toFinset_toMultiset
+More specific models give a trivial default instance
+of the less specific model.
+-/
 
-namespace ToList
+instance [ToFinset C τ] : ToSet C τ where
+  toSet c := toFinset c
+
+instance [DecidableEq τ] [ToMultiset C τ] : ToFinset C τ where
+  toFinset c := (toMultiset c).toFinset
+
+instance (priority := default + 1) [ToMultiset C τ] : ToSet C τ where
+  toSet c := (· ∈ toMultiset c)
 
 instance [ToList C τ] : ToMultiset C τ where
   toMultiset c := (toList c)
 
-instance [ToList C τ] : LawfulToList C τ where
-  toMultiset_toList _ := rfl
+/-! #### Lemmas -/
 
-def prod [ToList C₁ τ₁] [ToList C₂ τ₂] : ToList (C₁ × C₂) (τ₁ × τ₂) where
+namespace ToSet
+
+@[inline]
+def instProd [ToSet C₁ τ₁] [ToSet C₂ τ₂] : ToSet (C₁ × C₂) (τ₁ × τ₂) where
+  toSet := fun (c1,c2) => toSet c1 ×ˢ toSet c2
+
+@[inline]
+def instSum [ToSet C₁ τ₁] [ToSet C₂ τ₂] : ToSet (C₁ × C₂) (τ₁ ⊕ τ₂) where
+  toSet := fun (c1,c2) =>
+    ((toSet c1).image Sum.inl) ∪ ((toSet c2).image Sum.inr)
+
+@[inline]
+def instMap [ToSet C₁ τ₁] (fC : C₂ → C₁) (ft : τ₁ → τ₂) : ToSet C₂ τ₂ where
+  toSet c2 := toSet (fC c2) |>.image ft
+
+end ToSet
+
+namespace ToFinset
+
+@[simp]
+theorem toSet_toFinset [ToFinset C τ] (c : C) : (toFinset c).toSet = toSet c := rfl
+
+@[inline]
+def instProd [ToFinset C₁ τ₁] [ToFinset C₂ τ₂] : ToFinset (C₁ × C₂) (τ₁ × τ₂) where
+  toFinset := fun (c1,c2) => toFinset c1 ×ˢ toFinset c2
+
+@[inline]
+def instSum [ToFinset C₁ τ₁] [ToFinset C₂ τ₂] : ToFinset (C₁ × C₂) (τ₁ ⊕ τ₂) where
+  toFinset := fun (c1,c2) =>
+    Finset.disjSum (toFinset c1) (toFinset c2)
+
+@[inline]
+def instMap [ToFinset C₁ τ₁] (fC : C₂ → C₁) (ft : τ₁ ↪ τ₂) : ToFinset C₂ τ₂ where
+  toFinset c2 := toFinset (fC c2) |>.map ft
+
+end ToFinset
+
+namespace ToMultiset
+
+@[simp]
+theorem toFinset_toMultiset [DecidableEq τ] [ToMultiset C τ] (c : C)
+  : (toMultiset c).toFinset = toFinset c := rfl
+
+@[inline]
+def instProd [ToMultiset C₁ τ₁] [ToMultiset C₂ τ₂] : ToMultiset (C₁ × C₂) (τ₁ × τ₂) where
+  toMultiset := fun (c1,c2) => toMultiset c1 ×ˢ toMultiset c2
+
+@[inline]
+def instSum [ToMultiset C₁ τ₁] [ToMultiset C₂ τ₂] : ToMultiset (C₁ × C₂) (τ₁ ⊕ τ₂) where
+  toMultiset := fun (c1,c2) =>
+    (toMultiset c1).map Sum.inl + (toMultiset c2).map Sum.inr
+
+@[inline]
+def instMap [ToMultiset C₁ τ₁] (fC : C₂ → C₁) (ft : τ₁ → τ₂) : ToMultiset C₂ τ₂ where
+  toMultiset c2 := toMultiset (fC c2) |>.map ft
+
+end ToMultiset
+
+namespace ToList
+
+@[simp]
+theorem toMultiset_toList [ToList C τ] (c : C)
+  : Multiset.ofList (toList c) = toMultiset c := rfl
+
+@[simp]
+theorem toFinset_toList [ToList C τ] [DecidableEq τ] (c : C)
+  : (toList c).toFinset = toFinset c := rfl
+
+@[inline]
+def instProd [ToList C₁ τ₁] [ToList C₂ τ₂] : ToList (C₁ × C₂) (τ₁ × τ₂) where
   toList := fun (c1,c2) => toList c1 ×ˢ toList c2
 
-def sum [ToList C₁ τ₁] [ToList C₂ τ₂] : ToList (C₁ × C₂) (τ₁ ⊕ τ₂) where
+@[simp]
+theorem instProd.toToMultiset_eq_toMultiset_prod [ToList C₁ τ₁] [ToList C₂ τ₂] (c1 : C₁) (c2 : C₂)
+  : ↑(toList c1 ×ˢ toList c2) = toMultiset c1 ×ˢ toMultiset c2 := by
+  simp only [instToMultiset]
+  rw [Multiset.coe_product]
+
+@[inline]
+def instSum [ToList C₁ τ₁] [ToList C₂ τ₂] : ToList (C₁ × C₂) (τ₁ ⊕ τ₂) where
   toList := fun (c1,c2) =>
     (toList c1).map Sum.inl ++ (toList c2).map Sum.inr
+
+@[inline]
+def instMap [ToList C₁ τ₁] (fC : C₂ → C₁) (ft : τ₁ → τ₂) : ToList C₂ τ₂ where
+  toList c2 := toList (fC c2) |>.map ft
 
 end ToList
 
 
 /-! ### Operations Defined Elsewhere -/
 
-namespace Mem
-variable (C : Type u) (τ : outParam (Type v)) [Membership τ C]
+namespace Membership
 
-class ToFinset [ToFinset C τ] : Prop where
-  mem_iff_mem_toFinset : ∀ x (cont : C),
-    x ∈ cont ↔ x ∈ ToFinset.toFinset cont
+/-- Correctness of `Membership` against the `ToSet` model. -/
+class AgreesWithToSet (C : Type u) (τ : outParam (Type v)) [Membership τ C] [ToSet C τ] : Prop where
+  mem_iff_mem_toSet : ∀ x (cont : C), x ∈ cont ↔ x ∈ toSet cont
+export AgreesWithToSet (mem_iff_mem_toSet)
 
-class ToMultiset [ToMultiset C τ] : Prop where
-  mem_iff_mem_toMultiset : ∀ x (cont : C),
-    x ∈ cont ↔ x ∈ ToMultiset.toMultiset cont
+variable {C τ} [Membership τ C]
 
-class ToList [ToList C τ] : Prop where
-  mem_iff_mem_toList : ∀ x (cont : C),
-    x ∈ cont ↔ x ∈ ToList.toList cont
+/-!
+Simp normal form for membership is `x ∈ c` with the smallest expression `c`.
+-/
 
-end Mem
+@[simp] theorem mem_toSet_iff_mem (c : C) [ToSet C τ] [AgreesWithToSet C τ]
+  : x ∈ toSet c ↔ x ∈ c := by
+  simp [mem_iff_mem_toSet]
+
+@[simp] theorem mem_toFinset_iff_mem (c : C) [ToFinset C τ] [AgreesWithToSet C τ]
+  : x ∈ toFinset c ↔ x ∈ c := by
+  simp [← Finset.mem_coe]
+
+@[simp] theorem mem_toMultiset_iff_mem (c : C) [ToMultiset C τ] [AgreesWithToSet C τ]
+  : x ∈ toMultiset c ↔ x ∈ c := by
+  simp [mem_iff_mem_toSet, instToSet_1]
+  rfl
+
+@[simp] theorem mem_toList_iff_mem (c : C) [ToList C τ] [AgreesWithToSet C τ]
+  : x ∈ toList c ↔ x ∈ c := by
+  conv => rhs; rw [mem_iff_mem_toSet]
+
+/-! Different simp normal form would be to reduce membership to membership
+in the base model for the collection.
+
+TODO: how to handle this?
+-/
+
+theorem mem_toSet_iff_mem_toFinset [ToFinset C τ] (x : τ) (c : C) :
+    x ∈ toSet c ↔ x ∈ toFinset c := by rfl
+
+theorem mem_toSet_iff_mem_toMultiset [ToMultiset C τ] (x : τ) (c : C) :
+    x ∈ toSet c ↔ x ∈ toMultiset c := by rfl
+
+theorem mem_toFinset_iff_mem_toMultiset [ToMultiset C τ] [DecidableEq τ] (x : τ) (c : C) :
+    x ∈ toFinset c ↔ x ∈ toMultiset c := by
+  simp only [instToFinset, Multiset.mem_toFinset]
+
+theorem mem_toMultiset_iff_mem_toList [ToList C τ] (x : τ) (c : C) :
+    x ∈ toMultiset c ↔ x ∈ toList c := by
+  simp only [instToMultiset]; rw [Multiset.mem_coe]
+
+end Membership
 
 namespace Append
 variable (C : Type u) (τ : outParam (Type v)) [Append C]
 
-class ToList [ToList C τ] : Prop where
+class AgreesWithToList [ToList C τ] : Prop where
   toList_append : ∀ (c1 c2 : C),
     toList (c1 ++ c2) = toList c1 ++ toList c2
+export AgreesWithToList (toList_append)
 
-attribute [simp] ToList.toList_append
+attribute [simp] toList_append
 
 end Append
-
-export Functor (map)
 
 namespace Functor
 variable (C : Type u → Type v) [Functor C] (τ τ')

--- a/LeanColls/Classes/Seq.lean
+++ b/LeanColls/Classes/Seq.lean
@@ -87,10 +87,11 @@ namespace LeanColls
 
 class LawfulSeq (C : Type u) (τ : outParam (Type v)) [Seq C τ]
   extends
-    Mem.ToList C τ,
-    Append.ToList C τ,
-    Insert.ToMultiset C τ,
-    Fold.ToList C τ
+    Membership.AgreesWithToSet C τ,
+    Append.AgreesWithToList C τ,
+    Insert.AgreesWithToMultiset C τ,
+    Fold.LawfulFold C τ,
+    Fold.AgreesWithToMultiset C τ
   : Prop
   where
   size_def : ∀ (cont : C),
@@ -121,7 +122,7 @@ end LeanColls
 namespace List
 
 instance : LeanColls.LawfulSeq (List τ) τ where
-  mem_iff_mem_toList   := by simp
+  mem_iff_mem_toSet    := by intros; simp [LeanColls.instToSet_1]; rfl
   toList_append        := by simp
   toList_ofFn          := by simp
   toList_set           := by simp
@@ -137,9 +138,9 @@ instance : LeanColls.LawfulSeq (List τ) τ where
   toList_update := by intros; rfl
   toList_cons := by intros; rfl
   toList_snoc := by intros; rfl
-  fold_eq_fold_toList := by
+  exists_eq_list_foldl := by
     intro c
-    refine ⟨_, List.Perm.refl _, ?_⟩
+    refine ⟨_, rfl, ?_⟩
     intros; rfl
   foldM_eq_fold := by
     intros; simp [LeanColls.foldM, LeanColls.fold, List.foldlM_eq_foldl]
@@ -150,19 +151,17 @@ namespace LeanColls
 
 namespace Seq
 
-export Mem.ToList (
-  mem_iff_mem_toList
+export Membership.AgreesWithToSet (
+  mem_iff_mem_toSet
 )
 
-export Append.ToList (
+export Append.AgreesWithToList (
   toList_append
 )
-attribute [simp] toList_append
 
-export Insert.ToMultiset (
+export Insert.AgreesWithToMultiset (
   toMultiset_empty
 )
-attribute [simp] toMultiset_empty
 
 export LawfulSeq (
 size_def

--- a/LeanColls/Data/Array.lean
+++ b/LeanColls/Data/Array.lean
@@ -52,7 +52,10 @@ instance : Seq (Array α) α where
   getSnoc? := Array.getSnoc?
 
 instance : LawfulSeq (Array α) α where
-  mem_iff_mem_toList := by simp [LeanColls.toList, mem_def]
+  mem_iff_mem_toSet := by
+    simp [toSet, Set.mem_def, Array.mem_def, Membership.mem_toMultiset_iff_mem_toList]
+    simp only [← Array.toList_eq]
+    intros; rfl
   toList_append := by simp [LeanColls.toList]
   toMultiset_empty := by
     simp [LeanColls.toList, ToMultiset.toMultiset, LeanColls.empty, empty]
@@ -126,10 +129,12 @@ instance : LawfulSeq (Array α) α where
     simp [LeanColls.toList, Seq.cons, cons]
   toList_snoc := by
     simp [LeanColls.toList, Seq.snoc, snoc]
-  fold_eq_fold_toList := by
-    intro A; use A.toList; refine ⟨.rfl, ?_⟩
-    intros
-    simp [fold, foldl_eq_foldl_data]
+  exists_eq_list_foldl := by
+    intro A; use A.toList
+    constructor
+    · rfl
+    · intros
+      simp [fold, foldl_eq_foldl_data]
   foldM_eq_fold := by
     intros
     simp [fold, foldM]
@@ -152,8 +157,8 @@ instance : Fold ByteArray UInt8 where
   fold arr := arr.foldl
   foldM arr := arr.foldlM
 
-instance : Membership UInt8 ByteArray := Fold.toMem
---instance : Mem.ToList ByteArray UInt8 := Fold.toMem.ToList
+instance : Membership UInt8 ByteArray := Fold.instMem
+--instance : Membership.AgreesWithToSet ByteArray UInt8 := Fold.instMem.AgreesWithToSet
 
 instance : Seq ByteArray UInt8 where
   size := size
@@ -176,8 +181,8 @@ instance : Fold FloatArray Float where
   fold arr := arr.foldl
   foldM arr := arr.foldlM
 
-instance : Membership Float FloatArray := Fold.toMem
---instance : Mem.ToList FloatArray Float := Fold.toMem.ToList
+instance : Membership Float FloatArray := Fold.instMem
+--instance : Mem.ToList FloatArray Float := Fold.instMem.AgreesWithToSet
 
 def append (A1 A2 : FloatArray) : FloatArray :=
   aux A1 0

--- a/LeanColls/Data/AssocList.lean
+++ b/LeanColls/Data/AssocList.lean
@@ -32,16 +32,18 @@ instance : Fold (AssocList κ τ) (κ × τ) where
 instance : ToList (AssocList κ τ) (κ × τ) where
   toList := Std.AssocList.toList
 
-instance : Fold.ToList (AssocList κ τ) (κ × τ) where
-  fold_eq_fold_toList := by
-    intro c
-    use c.toList
-    simp only [toList]
-    simp [fold]
+instance : Fold.LawfulFold (AssocList κ τ) (κ × τ) where
   foldM_eq_fold := by
     simp [foldM, fold]
     intros
     rw [List.foldlM_eq_foldl]
+
+instance : Fold.AgreesWithToMultiset (AssocList κ τ) (κ × τ) where
+  exists_eq_list_foldl := by
+    intro c
+    use c.toList
+    simp only [toMultiset, toList]
+    simp [fold]
 
 instance [BEq κ] : Membership (κ × τ) (AssocList κ τ) where
   mem := fun (k,t) m => m.find? k = some t
@@ -53,18 +55,22 @@ instance : Fold (Dict.KeySet (AssocList κ τ)) κ where
 instance : ToList (Dict.KeySet (AssocList κ τ)) (κ) where
   toList := fun ⟨al⟩ => al.toList.map (·.1)
 
-instance : Fold.ToList (Dict.KeySet (AssocList κ τ)) κ where
-  fold_eq_fold_toList := by
-    intro c
-    use c.data.toList.map (·.1)
-    simp only [toList]
-    simp [fold, List.foldl_map]
+instance : Fold.LawfulFold (Dict.KeySet (AssocList κ τ)) κ where
   foldM_eq_fold := by
     simp [foldM, fold]
     intros
     rw [List.foldlM_eq_foldl]
 
-instance [DecidableEq κ] : Membership κ (Dict.KeySet (AssocList κ τ)) := Fold.toMem
+instance [DecidableEq κ] : Membership κ (Dict.KeySet (AssocList κ τ)) := Fold.instMem
+
+instance : Fold.AgreesWithToMultiset (Dict.KeySet (AssocList κ τ)) κ where
+  exists_eq_list_foldl := by
+    intro c
+    use c.data.toList.map (·.1)
+    simp only [toMultiset, toList]
+    simp [fold, List.foldl_map]
+
+instance [DecidableEq κ] : Membership κ (Dict.KeySet (AssocList κ τ)) := Fold.instMem
 
 -- TODO(JG)
 instance [DecidableEq κ] : Dict (AssocList κ τ) κ τ where


### PR DESCRIPTION
Big refactor of `Ops.lean`.

- Improves class names to be consistent/predictable
- Refactors `Fold` correctness to be in terms of `ToMultiset` instead of list permutations. This includes some lemmas about multiset induction to prove properties of a fold.
- Adds `ToSet` class as the top of the collection model hierarchy