### PR TITLE
feat: better Dict interface

### DIFF
--- a/LeanColls/Classes/Bag.lean
+++ b/LeanColls/Classes/Bag.lean
@@ -25,10 +25,15 @@ do not include a way to insert or remove elements.
 
 namespace LeanColls
 
-/-- [Bag] operations expected on read-only "set-like" collections. -/
+/-- [Bag] operations expected on read-only "set-like" collections.
+
+Note that this requires `ToMultiset` even though the model is `ToFinset`;
+lawfulness is stated in terms of `ToFinset`,
+but some `Bag`s can't provide `ToFinset` without some extra hypotheses.
+-/
 class Bag.ReadOnly (C : Type u) (τ : outParam (Type v)) extends
   Membership τ C,
-  ToFinset C τ,
+  ToMultiset C τ,
   Fold C τ,
   Size C
 

--- a/LeanColls/Classes/Dict.lean
+++ b/LeanColls/Classes/Dict.lean
@@ -15,7 +15,7 @@ namespace LeanColls
 
 namespace Dict
 
-/-- Represents the key set of a `C` map.
+/-- Represents the key set of a `C` dictionary.
 
 This is a trivial wrapper structure,
 on which dictionary implementations should provide a `Bag` instance.
@@ -26,23 +26,30 @@ structure KeySet (C : Type u) where
 end Dict
 
 class Dict (C : Type u) (κ : outParam (Type v)) (τ : outParam (Type w))
-  extends MultiBag C (κ × τ) where
+  extends Bag C (κ × τ) where
+
   /-- The [Bag] instance providing functions on this collection's [KeySet]. -/
   toBagKeySet : Bag.ReadOnly (Dict.KeySet C) κ
+
   /-- Look up `k` in collection `cont` -/
   get? : (cont : C) → (k : κ) → Option τ
+
   /-- Alter the entry at key `k` in `cont`.
     The `f` is given the current value at `k`,
     or none if not defined at `k`.
     If `f` returns `none`, `k` is erased. -/
   alter : (cont : C) → (k : κ) → (f : Option τ → Option τ) → C
+
   /-- Set the entry at key `k` to `v` in `cont`. -/
   set : (cont : C) → (k : κ) → (v : τ) → C := (alter · · <| Function.const _ <| some ·)
+
   /-- Modify the value at key `k`, if present, by applying `f`.
     Otherwise leave the map unchanged. -/
   modify : (cont : C) → (k : κ) → (f : τ → τ) → C := (alter · · <| Option.map · )
+
   /-- Remove the entry at key `k`, if present. -/
   remove : (cont : C) → (k : κ) → C := (alter · · (Function.const _ none))
+
 
 attribute [instance] Dict.toBagKeySet
 

--- a/LeanColls/Data/AssocList.lean
+++ b/LeanColls/Data/AssocList.lean
@@ -9,31 +9,69 @@ import LeanColls.Data.Transformer.View
 
 import Std.Data.AssocList
 
+/-! ### AssocList
+
+This file hooks `Std.AssocList` and mathlib's `AList`
+into the `LeanColls` framework.
+
+Note `AssocList` has a very ugly theory without an assumption
+that there are no duplicate keys.
+Mathlib's `AList` has a nicer theory but worse computational properties.
+-/
 
 namespace LeanColls
 
 export Std (AssocList)
 
+namespace AssocList
+
 instance : Fold (AssocList κ τ) (κ × τ) where
   fold := fun m f init => m.foldl (fun acc k t => f acc (k,t)) init
   foldM := fun m f init => m.foldlM (fun acc k t => f acc (k,t)) init
+
+instance : ToList (AssocList κ τ) (κ × τ) where
+  toList := Std.AssocList.toList
+
+instance : Fold.ToList (AssocList κ τ) (κ × τ) where
+  fold_eq_fold_toList := by
+    intro c
+    use c.toList
+    simp only [toList]
+    simp [fold]
+  foldM_eq_fold := by
+    simp [foldM, fold]
+    intros
+    rw [List.foldlM_eq_foldl]
+
+instance [BEq κ] : Membership (κ × τ) (AssocList κ τ) where
+  mem := fun (k,t) m => m.find? k = some t
 
 instance : Fold (Dict.KeySet (AssocList κ τ)) κ where
   fold := fun m f init => m.data.foldl (fun acc k _ => f acc k) init
   foldM := fun m f init => m.data.foldlM (fun acc k _ => f acc k) init
 
-instance : Membership (κ × τ) (AssocList κ τ) := Fold.toMem
---instance : Mem.ToList (AssocList κ τ) (κ × τ) := Fold.toMem.ToList
+instance : ToList (Dict.KeySet (AssocList κ τ)) (κ) where
+  toList := fun ⟨al⟩ => al.toList.map (·.1)
 
-instance : Membership κ (Dict.KeySet (AssocList κ τ)) := Fold.toMem
---instance : Mem.ToList (Dict.KeySet (AssocList κ τ)) κ := Fold.toMem.ToList
+instance : Fold.ToList (Dict.KeySet (AssocList κ τ)) κ where
+  fold_eq_fold_toList := by
+    intro c
+    use c.data.toList.map (·.1)
+    simp only [toList]
+    simp [fold, List.foldl_map]
+  foldM_eq_fold := by
+    simp [foldM, fold]
+    intros
+    rw [List.foldlM_eq_foldl]
 
-instance [BEq κ] : Dict (AssocList κ τ) κ τ where
-  mem := fun (k,t) m => m.find? k = some t
-  toMultiset := fun m => m.toList
+instance [DecidableEq κ] : Membership κ (Dict.KeySet (AssocList κ τ)) := Fold.toMem
+
+-- TODO(JG)
+instance [DecidableEq κ] : Dict (AssocList κ τ) κ τ where
   size := fun m => m.length
   empty := .nil
   insert := fun m (k,t) => m.cons k t
+  toMultiset := fun m => m.toList
   get? := fun m k => m.find? k
   set := fun m k x => m.erase k |>.cons k x
   remove := fun m k => m.erase k
@@ -49,8 +87,9 @@ instance [BEq κ] : Dict (AssocList κ τ) κ τ where
       match f (some v) with
       | none => m.erase k
       | some v' => m.replace k v'
-  -- TODO need de-duplication stuff
   toBagKeySet := {
-    toFinset := sorry
-    size := sorry
+    toMultiset := fun ⟨m⟩ => m.toList.map (·.1)
+    size := fun ⟨m⟩ => m.length
   }
+
+end AssocList

--- a/LeanColls/Data/HashMap.lean
+++ b/LeanColls/Data/HashMap.lean
@@ -7,7 +7,13 @@ import LeanColls.Classes.Dict
 import LeanColls.Data.Transformer.View
 
 import Std.Data.HashMap
+import Std.Data.HashMap.Lemmas
 
+/-! ### HashMap
+
+Very few facts are proven about HashMap,
+so we do not even attempt the lawfulness proofs.
+-/
 
 namespace LeanColls
 
@@ -23,9 +29,14 @@ instance : Fold (Dict.KeySet (HashMap κ τ)) κ where
   fold := fun m f init => m.data.fold (fun acc k _ => f acc k) init
   foldM := fun m f init => m.data.foldM (fun acc k _ => f acc k) init
 
-instance : Dict (HashMap κ τ) κ τ where
+instance : ToList (HashMap κ τ) (κ × τ) where
+  toList := Std.HashMap.toList
+
+instance : Membership (κ × τ) (HashMap κ τ) where
   mem := fun (k,t) m => m.find? k = some t
-  toMultiset := fun m => m.toList
+
+instance : Dict (HashMap κ τ) κ τ where
+  toMultiset m := m.toList
   fold := fun m f init => m.fold (fun acc k t => f acc (k,t)) init
   size := fun m => m.size
   empty := .empty
@@ -40,7 +51,7 @@ instance : Dict (HashMap κ τ) κ τ where
     | some _, none => m.erase k
   modify := fun m k f => m.modify k (Function.const _ f)
   toBagKeySet := {
-    mem := fun x m => m.data.contains x
-    size := fun s => s.data.size
-    toFinset := sorry
+    mem := fun x ⟨m⟩ => m.contains x
+    size := fun ⟨m⟩ => m.size
+    toMultiset := fun ⟨m⟩ => m.toList.map (·.1)
   }

--- a/LeanColls/Data/RBMap.lean
+++ b/LeanColls/Data/RBMap.lean
@@ -22,8 +22,16 @@ instance [Ord κ] : Fold (Dict.KeySet (RBMap κ τ)) κ where
   fold := fun m f init => m.data.data.foldl (fun acc k _ => f acc k) init
   foldM := fun m f init => m.data.data.foldlM (fun acc k _ => f acc k) init
 
-instance [Ord κ] : Dict (RBMap κ τ) κ τ where
+instance [Ord κ] : Membership (κ × τ) (RBMap κ τ) where
   mem := fun (k,t) m => m.data.find? k = some t
+
+instance [Ord κ] : Membership κ (Dict.KeySet (RBMap κ τ)) where
+  mem := fun k ⟨m⟩ => m.data.keys.contains k
+
+instance [Ord κ] : Bag.ReadOnly (Dict.KeySet (RBMap κ τ)) κ where
+  toMultiset := fun ⟨m⟩ => m.data.keysList
+
+instance [Ord κ] : Dict (RBMap κ τ) κ τ where
   toMultiset := fun m => m.data.toList
   size := fun m => m.data.size
   empty := ⟨.empty⟩
@@ -32,8 +40,4 @@ instance [Ord κ] : Dict (RBMap κ τ) κ τ where
   set := fun m k x => ⟨m.data.insert k x⟩
   modify := fun m k f => ⟨m.data.modify k f⟩
   alter := fun m k f => ⟨m.data.alter k f⟩
-  toBagKeySet := {
-    mem := fun x m => m.data.data.contains x
-    toFinset := sorry
-    size := fun m => m.data.data.size
-  }
+  toBagKeySet := inferInstance


### PR DESCRIPTION
Now dictionaries are `Bag`s rather than `MultiBag`s, and `Bag`s only require a `ToMultiset` function rather than the (much stronger) requirement of a `ToFinset` function